### PR TITLE
use v1 layout for directory layout

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
 
 	"github.com/lf-edge/edge-containers/pkg/registry"
-	ecresolver "github.com/lf-edge/edge-containers/pkg/resolver"
 	"github.com/lf-edge/edge-containers/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -34,11 +32,7 @@ var pullCmd = &cobra.Command{
 		puller := registry.Puller{
 			Image: image,
 		}
-		_, resolver, err := ecresolver.NewRegistry(context.TODO())
-		if err != nil {
-			log.Fatalf("unexpected error when created NewRegistry resolver: %v", err)
-		}
-		desc, artifact, err := puller.Pull(registry.DirTarget{Dir: pullDir}, blocksize, verbose, os.Stdout, resolver)
+		desc, artifact, err := puller.Pull(registry.DirTarget{Dir: pullDir}, blocksize, verbose, os.Stdout, remoteTarget)
 		if err != nil {
 			log.Fatalf("error pulling from registry: %v", err)
 		}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -58,11 +58,15 @@ var pushCmd = &cobra.Command{
 		}
 
 		// construct and pass along
+		var config registry.Source
+		if configFile != "" {
+			config = &registry.FileSource{Path: configFile}
+		}
 		artifact := &registry.Artifact{
 			Kernel: &registry.FileSource{Path: kernelFile},
 			Initrd: &registry.FileSource{Path: initrdFile},
 			Root:   rootDisk,
-			Config: &registry.FileSource{Path: configFile},
+			Config: config,
 			Disks:  addlDisks,
 		}
 		pusher := registry.Pusher{


### PR DESCRIPTION
When using a `--remote=/tmp/foo`, use the v1 layout spec rather than the strange custom thing we created.