### PR TITLE
do not retype official types strings

### DIFF
--- a/pkg/registry/mimeTypes.go
+++ b/pkg/registry/mimeTypes.go
@@ -1,5 +1,10 @@
 package registry
 
+import (
+	"github.com/containerd/containerd/images"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 const (
 	MimeTypeECIConfig           = "application/vnd.lfedge.eci.config.v1+json"
 	MimeTypeECIKernel           = "application/vnd.lfedge.eci.kernel.layer.v1+kernel"
@@ -13,16 +18,16 @@ const (
 	MimeTypeECIDiskOva          = "application/vnd.lfedge.disk.layer.v1+ova"
 	MimeTypeECIDiskVhdx         = "application/vnd.lfedge.disk.layer.v1+vhdx"
 	MimeTypeECIOther            = "application/vnd.lfedge.eci.layer.v1"
-	MimeTypeOCIImageConfig      = "application/vnd.oci.image.config.v1+json"
-	MimeTypeOCIImageLayer       = "application/vnd.oci.image.layer.v1.tar"
-	MimeTypeOCIImageLayerGzip   = "application/vnd.oci.image.layer.v1.tar+gzip"
-	MimeTypeOCIImageManifest    = "application/vnd.oci.image.manifest.v1+json"
-	MimeTypeOCIImageIndex       = "application/vnd.oci.image.index.v1+json"
-	MimeTypeDockerImageConfig   = "application/vnd.docker.container.image.v1+json"
-	MimeTypeDockerImageManifest = "application/vnd.docker.distribution.manifest.v2+json"
-	MimeTypeDockerImageIndex    = "application/vnd.docker.distribution.manifest.list.v2+json"
-	MimeTypeDockerLayerTarGzip  = "application/vnd.docker.image.rootfs.diff.tar.gzip"
-	MimeTypeDockerLayerTar      = "application/vnd.docker.image.rootfs.diff.tar"
+	MimeTypeOCIImageConfig      = ocispec.MediaTypeImageConfig
+	MimeTypeOCIImageLayer       = ocispec.MediaTypeImageLayer
+	MimeTypeOCIImageLayerGzip   = ocispec.MediaTypeImageLayerGzip
+	MimeTypeOCIImageManifest    = ocispec.MediaTypeImageManifest
+	MimeTypeOCIImageIndex       = ocispec.MediaTypeImageIndex
+	MimeTypeDockerImageConfig   = images.MediaTypeDockerSchema2Config
+	MimeTypeDockerImageManifest = images.MediaTypeDockerSchema2Manifest
+	MimeTypeDockerImageIndex    = images.MediaTypeDockerSchema2ManifestList
+	MimeTypeDockerLayerTarGzip  = images.MediaTypeDockerSchema2LayerGzip
+	MimeTypeDockerLayerTar      = images.MediaTypeDockerSchema2Layer
 )
 
 var allTypes = []string{
@@ -69,4 +74,12 @@ func GetConfigMediaType(actualType string, format Format) string {
 		return actualType
 	}
 	return MimeTypeOCIImageConfig
+}
+
+func IsConfigType(mediaType string) bool {
+	switch mediaType {
+	case MimeTypeECIConfig, MimeTypeOCIImageConfig, MimeTypeDockerImageConfig:
+		return true
+	}
+	return false
 }

--- a/pkg/registry/target.go
+++ b/pkg/registry/target.go
@@ -106,8 +106,7 @@ func (f *FilesTarget) Writer(ctx context.Context, opts ...ctrcontent.WriterOpt) 
 	// save any config
 	// because the config always is pulled first, this should work. But it depends on this remaining the same:
 	// https://github.com/containerd/containerd/blob/178e9a10121b344aece9fe918f6fc4dc4dbde9a3/images/image.go#L346-L347
-	switch desc.MediaType {
-	case MimeTypeECIConfig, MimeTypeOCIImageConfig, MimeTypeDockerImageConfig:
+	if IsConfigType(desc.MediaType) {
 		// process the config, looking for annotations
 		return f.configIngestor(), nil
 	}


### PR DESCRIPTION
No functionality change, but we had types out the strings, as opposed to referencing them.