### PR TITLE
Use io.ReadFull to read defined size

### DIFF
--- a/pkg/registry/pull.go
+++ b/pkg/registry/pull.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	ctrcontent "github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
@@ -159,13 +158,13 @@ func findConfig(ctx context.Context, provider ctrcontent.Provider, os, arch stri
 			var (
 				conf   ocispec.Image
 				reader ctrcontent.ReaderAt
-				data   []byte
 			)
 			reader, err = provider.ReaderAt(ctx, d)
 			if err != nil {
 				continue
 			}
-			data, err = ioutil.ReadAll(content.NewReaderAtWrapper(reader))
+			data := make([]byte, d.Size)
+			_, err = io.ReadFull(content.NewReaderAtWrapper(reader), data)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
We should use io.ReadFull to ensure that we will read all data to fill expected size. oras implementation use [io.ReadFull](https://github.com/oras-project/oras-go/pull/142/commits/127af01a27db3a6b7fef2929db2089c14ed8e195), so we should read with predefined buffer, to not get unexpected EOF (and silently ignore it).


Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>